### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-First you should quickly watch the introductory stream HERE. It will quickly catch you up to speed on how to contribute to the library, what the overall sprint will look like, as well as the recommended way to create your first PR!
+First you should quickly watch the introductory stream [fastai docments Sprint Kick-Off](https://www.youtube.com/watch?v=luzrkNfBT4U&ab_channel=ZacharyMueller). It will quickly catch you up to speed on how to contribute to the library, what the overall sprint will look like, as well as the recommended way to create your first PR!
 
 Below are quick TL;DR's of what is stated in the video, meant as a quick reminder plus important links.
 
@@ -16,13 +16,13 @@ More specifically, anyone and everyone is invited to come along and help with th
 
 ## Communication
 
-Most of the repository of this sprint will live inside of the fastai [discord](https://discord.gg/3KmGsdMRFH). Inside, you can ping any of the senior members acting as guides throughout this sprint with any troubles, discuss the right way to approach a strange class, or just come say hi!
+Most of the communication of this sprint will live inside of the fastai [discord](https://discord.gg/3KmGsdMRFH). Inside, you can ping any of the senior members acting as guides throughout this sprint with any troubles, discuss the right way to approach a strange class, or just come say hi!
 
 I (Zach Mueller) will also be commiting to streaming for 2-3 hours for at least 4-5 days a week in the evenings (around 6pm EST) inside the Discord, with a few streams in the early morning for folks in other timezones. To keep an ear out for when I stream either keep an eye on the discord, or follow me on [twitter](https://twitter.com/TheZachMueller).
 
 ## How do I "docment"? What is that?
 
-A sprint-specific style guide is available [here](https://github.com/muellerzr/fastai-docment-sprint/blob/master/docs_src/dev/style-guide.md) detailing this process, and the overall fastai-specific style-guide is available [here](https://docs.fast.ai/dev/style.html).
+A sprint-specific style guide is available [here](https://github.com/muellerzr/fastai-docment-sprint/blob/master/docs_src/style-guide.md) detailing this process, and the overall fastai-specific style-guide is available [here](https://docs.fast.ai/dev/style.html).
 
 ## How do I begin?
 

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "## Getting Started\n",
     "\n",
-    "First you should quickly watch the introductory stream HERE. It will quickly catch you up to speed on how to contribute to the library, what the overall sprint will look like, as well as the recommended way to create your first PR!\n",
+    "First you should quickly watch the introductory stream [fastai docments Sprint Kick-Off](https://www.youtube.com/watch?v=luzrkNfBT4U&ab_channel=ZacharyMueller). It will quickly catch you up to speed on how to contribute to the library, what the overall sprint will look like, as well as the recommended way to create your first PR!\n",
     "\n",
     "Below are quick TL;DR's of what is stated in the video, meant as a quick reminder plus important links."
    ]
@@ -39,7 +39,7 @@
    "source": [
     "## Communication\n",
     "\n",
-    "Most of the repository of this sprint will live inside of the fastai [discord](https://discord.gg/3KmGsdMRFH). Inside, you can ping any of the senior members acting as guides throughout this sprint with any troubles, discuss the right way to approach a strange class, or just come say hi!\n",
+    "Most of the communication of this sprint will live inside of the fastai [discord](https://discord.gg/3KmGsdMRFH). Inside, you can ping any of the senior members acting as guides throughout this sprint with any troubles, discuss the right way to approach a strange class, or just come say hi!\n",
     "\n",
     "I (Zach Mueller) will also be commiting to streaming for 2-3 hours for at least 4-5 days a week in the evenings (around 6pm EST) inside the Discord, with a few streams in the early morning for folks in other timezones. To keep an ear out for when I stream either keep an eye on the discord, or follow me on [twitter](https://twitter.com/TheZachMueller)."
    ]
@@ -50,7 +50,7 @@
    "source": [
     "## How do I \"docment\"? What is that?\n",
     "\n",
-    "A sprint-specific style guide is available [here](https://github.com/muellerzr/fastai-docment-sprint/blob/master/docs_src/dev/style-guide.md) detailing this process, and the overall fastai-specific style-guide is available [here](https://docs.fast.ai/dev/style.html)."
+    "A sprint-specific style guide is available [here](https://github.com/muellerzr/fastai-docment-sprint/blob/master/docs_src/style-guide.md) detailing this process, and the overall fastai-specific style-guide is available [here](https://docs.fast.ai/dev/style.html)."
    ]
   },
   {


### PR DESCRIPTION
- Added link to the fastai docments Sprint kick-off YouTube stream to the README file.
- Fixed broken link to sprint specific style guide
- Fixed a minor typo in README.md

Please feel free to modify this commit to your liking or let me know if I need to change anything :relaxed: 