### PR TITLE
Update original README about dependencies required to run the tests.

### DIFF
--- a/docs/index_original.html
+++ b/docs/index_original.html
@@ -144,10 +144,8 @@ pip install -e "fastai[dev]"</code></pre>
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>To run the tests in parallel, launch:</p>
 <p><a href="https://nbdev.fast.ai/test#nbdev_test_nbs"><code>nbdev_test_nbs</code></a> or <code>make test</code></p>
-<p>For all the tests to pass, you'll need to install the following optional dependencies:</p>
-
-<pre><code>pip install "sentencepiece&lt;0.1.90" wandb tensorboard albumentations pydicom opencv-python scikit-image pyarrow kornia \
-    catalyst captum neptune-cli</code></pre>
+<p>For all the tests to pass, you'll need to install the dependencies specified as part of dev_requirements in settings.ini</p>
+<p><code>pip install -e .[dev]</code></p>
 <p>Tests are written using <code>nbdev</code>, for example see the documentation for <a href="https://fastcore.fast.ai/test#test_eq"><code>test_eq</code></a>.</p>
 
 </div>

--- a/nbs/index_original.ipynb
+++ b/nbs/index_original.ipynb
@@ -160,12 +160,9 @@
     "\n",
     "`nbdev_test_nbs` or `make test`\n",
     "\n",
-    "For all the tests to pass, you'll need to install the following optional dependencies:\n",
+    "For all the tests to pass, you'll need to install the dependencies specified as part of dev_requirements in settings.ini\n",
     "\n",
-    "```\n",
-    "pip install \"sentencepiece<0.1.90\" wandb tensorboard albumentations pydicom opencv-python scikit-image pyarrow kornia \\\n",
-    "    catalyst captum neptune-cli\n",
-    "```\n",
+    "`pip install -e .[dev]` \n",
     "\n",
     "Tests are written using `nbdev`, for example see the documentation for `test_eq`."
    ]

--- a/settings.ini
+++ b/settings.ini
@@ -16,7 +16,7 @@ language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.3.27,<1.4 torchvision>=0.8.2 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>6.0.0 scikit-learn scipy spacy<4 packaging
 pip_requirements = torch>=1.7.0,<1.11
 conda_requirements = pytorch>=1.7.0,<1.11
-dev_requirements = nbdev>=1.0.22,<2 ipywidgets pytorch-lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.3 flask wandb azureml-sdk kornia scikit-image neptune-client albumentations opencv-python pyarrow catalyst ninja
+dev_requirements = nbdev>=1.0.22,<2 ipywidgets pytorch-lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.3 flask wandb kornia scikit-image neptune-client albumentations opencv-python pyarrow catalyst ninja
 nbs_path = nbs
 doc_path = docs
 doc_src_path = docs_src


### PR DESCRIPTION
This is a clone of https://github.com/muellerzr/fastai-docment-sprint/pull/2. To keep the PR short, I have updated only the changes required to run the tests.

- sentencepiece is no more version constrained as per dev_requirements.
- Removed the outdated instruction about the dependencies required and updated.

Will close [PR2](https://github.com/muellerzr/fastai-docment-sprint/pull/2). We can tackle azureml-sdk separately since it is not supported in python 3.9.  

 

