### PR TITLE
fixing the "forked" version of compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ venv.bak/
 
 # Mac stuff
 .DS_Store
+
+# docker related files
+docker.compose.fork.yml

--- a/docker-compose.fork.yml
+++ b/docker-compose.fork.yml
@@ -12,12 +12,14 @@ services:
     tty: true
     volumes:
       - .:/data/
+    environment:
+      - LIB_INSTALL_TYPE=.[dev] #optionally change this locally to .[dev] to install dev packages as well
 
   notebook:
     <<: *fastai
     command: >
-     bash -c "pip install -e \".[dev]\" 
-     && nbdev_install_git_hooks
+     bash -c "pip install -e $$LIB_INSTALL_TYPE 
+     && nbdev_install_git_hooks 
      && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
     ports:
       - "9999:8080"
@@ -26,14 +28,14 @@ services:
     <<: *fastai
     command: watchmedo shell-command --command nbdev_build_docs --pattern *.ipynb --recursive --drop
     network_mode: host # for GitHub Codespaces https://github.com/features/codespaces/
- 
+
   jekyll:
     <<: *fastai
     ports:
      - "4000:4000"
     command: >
-     bash -c "cp -r docs_src docs
-     && pip install .
+     bash -c "cp -r ./docs_src/. ./docs/
+     && pip install $$LIB_INSTALL_TYPE
      && nbdev_build_docs && cd docs
      && bundle i
      && bundle exec jekyll serve --host 0.0.0.0"

--- a/docker-compose.fork.yml.template
+++ b/docker-compose.fork.yml.template
@@ -17,7 +17,10 @@ services:
 
   notebook:
     <<: *fastai
-    command: bash -c "pip install -e $$LIB_INSTALL_TYPE && nbdev_install_git_hooks && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
+    command: >
+     bash -c "pip install -e $$LIB_INSTALL_TYPE 
+     && nbdev_install_git_hooks 
+     && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
     ports:
       - "8080:8080"
 

--- a/docker-compose.fork.yml.template
+++ b/docker-compose.fork.yml.template
@@ -1,0 +1,38 @@
+version: "3"
+services:
+  fastai: &fastai
+    restart: unless-stopped
+    working_dir: /data
+    image: fastai/codespaces
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/data/
+    environment:
+      - LIB_INSTALL_TYPE=.[dev] #optionally change this locally to .[dev] to install dev packages as well
+
+  notebook:
+    <<: *fastai
+    command: bash -c "pip install -e $$LIB_INSTALL_TYPE && nbdev_install_git_hooks && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
+    ports:
+      - "8080:8080"
+
+  watcher:
+    <<: *fastai
+    command: watchmedo shell-command --command nbdev_build_docs --pattern *.ipynb --recursive --drop
+    network_mode: host # for GitHub Codespaces https://github.com/features/codespaces/
+
+  jekyll:
+    <<: *fastai
+    ports:
+     - "4000:4000"
+    command: >
+     bash -c "cp -r ./docs_src/. ./docs/
+     && pip install $$LIB_INSTALL_TYPE
+     && nbdev_build_docs && cd docs
+     && bundle i
+     && bundle exec jekyll serve --host 0.0.0.0"


### PR DESCRIPTION
Three changes:

1. Renamed the .yml file to be `docker-compose.fork.yml.template`
2. Added `docker-compose.fork.yml` to `.gitignore`
3. Fixed the jekyll image to properly move files form `./docs_src` into `./docs`﻿
